### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=Multi_BitBang
+version=0.0.0
+author=Larry Bank
+maintainer=Larry Bank
+sentence=Bit-bang the I2C protocol on multiple GPIO pins on any system.
+paragraph=
+category=Communication
+url=https://github.com/bitbank2/Multi_BitBang
+architectures=*
+includes=Multi_BitBang.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the [Arduino Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata